### PR TITLE
chore: upgrade Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ===== Stage 1: Builder =====
-FROM golang:1.25 AS builder
+FROM golang:1.26.3 AS builder
 WORKDIR /app
 
 # Copy go.mod and go.sum first to leverage caching for dependencies.
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o docker-coredns-sync ./
 
 
 # ===== Stage 2: Development Environment =====
-FROM golang:1.25 AS dev
+FROM golang:1.26.3 AS dev
 WORKDIR /workspace
 RUN groupadd --gid 1000 vscode && \
     useradd --uid 1000 --gid vscode -m vscode

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-dns/docker-coredns-sync
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/docker/docker v28.0.4+incompatible


### PR DESCRIPTION
## Summary
- Update `go` directive in `go.mod` from 1.25.0 to 1.26.3
- Update builder and dev Dockerfile stages from `golang:1.25` to `golang:1.26.3`

## Test plan
- [ ] CI builds Docker image successfully on the new base

🤖 Generated with [Claude Code](https://claude.com/claude-code)