### PR TITLE
ci+docs: awaiting-release automation and contributor conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Linked issues
+
+<!--
+Use a GitHub closing keyword so the issue auto-closes when the release branch
+merges to main, and gets the `awaiting-release` label when this PR merges into a
+release branch. e.g. "Closes #123".
+-->
+Closes #
+
+## Checklist
+
+- [ ] Targets the active release branch (`vMAJOR.MINOR.PATCH`), not `main`
+- [ ] `go test -race ./...` passes and `make lint` is clean
+- [ ] Updated `CHANGELOG.md` under `## [Unreleased]`

--- a/.github/workflows/awaiting-release.yaml
+++ b/.github/workflows/awaiting-release.yaml
@@ -1,0 +1,65 @@
+name: Mark merged issues awaiting-release
+
+# When a PR is merged into a release/integration branch (e.g. v0.7.0), label the
+# issues it closes with `awaiting-release`. This distinguishes work that is
+# implemented and merged-but-not-yet-released from issues still open for
+# development. The issues stay open and auto-close when the release branch is
+# merged into the default branch (the `Closes #N` keywords fire there).
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'v*' # release/integration branches only, not the default branch
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  awaiting-release:
+    name: Label closed issues
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label issues referenced by the merged PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'awaiting-release';
+
+            // Ensure the label exists with a recognizable color/description.
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'fbca04',
+                description: 'Implemented and merged to a release branch; not yet released',
+              });
+            } catch (e) {
+              if (e.status !== 422) throw e; // 422 = label already exists
+            }
+
+            // Collect issues referenced by GitHub closing keywords in the PR body.
+            const body = context.payload.pull_request.body || '';
+            const re = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const issues = new Set();
+            let m;
+            while ((m = re.exec(body)) !== null) {
+              issues.add(Number(m[1]));
+            }
+
+            if (issues.size === 0) {
+              core.info('No closing references (Closes/Fixes/Resolves #N) found in PR body.');
+              return;
+            }
+
+            for (const number of issues) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                labels: [label],
+              });
+              core.info(`Labeled #${number} ${label}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,18 @@ When two containers want the same DNS name:
 ### Config
 
 Config is handled by Viper in `internal/config/config.go`. The etcd connection takes `endpoints` as a `[]string` (e.g., `["http://etcd:2379"]`). `app.hostname` must be unique per node — it's used to scope ownership of etcd records.
+
+## Versioning, branches & releases
+
+See `CONTRIBUTING.md` for the full contributor guide. Key conventions:
+
+- **Versioning:** [SemVer](https://semver.org/); active line is **0.7.x**. Record changes in `CHANGELOG.md` (Keep a Changelog) under `## [Unreleased]` in the same PR.
+- **Branches:** `main` is the default/stable branch. Each release is integrated on a release branch named `vMAJOR.MINOR.PATCH` (e.g. `v0.7.0`); open PRs against the **active release branch**, not `main`. The release branch later merges into `main` and is tagged.
+- **Tags & releases:** pushing a tag `vMAJOR.MINOR.PATCH` (pre-release: `vMAJOR.MINOR.PATCH-SUFFIX`) triggers `.github/workflows/docker.yaml`, which builds/pushes the GHCR image and cuts a GitHub Release from the matching `## [MAJOR.MINOR.PATCH]` CHANGELOG section. Rename `## [Unreleased]` to the versioned heading before tagging.
+
+## Pull request conventions
+
+- Target the active release branch (`vMAJOR.MINOR.PATCH`), not `main`.
+- Link issues with closing keywords in the PR body — `Closes #N` / `Fixes #N` / `Resolves #N`. Merging to `main` auto-closes them; merging to a release branch (`v*`) labels them `awaiting-release` via `.github/workflows/awaiting-release.yaml`.
+- **Issue state** encodes pipeline position: open without `awaiting-release` = open for development; open + `awaiting-release` = merged to a release branch, not yet released; closed = released.
+- Keep changes covered by tests (`go test -race ./...`), run `make lint`/`make format`, and update `CHANGELOG.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `CONTRIBUTING.md` documenting versioning, branch, tag/release, issue, and
+  pull-request conventions; a pull request template; and a workflow that labels
+  issues `awaiting-release` when their PR merges into a release branch.
 - Dry-run mode (`app.dry_run` / `--app.dry-run`): the reconciliation loop logs
   the planned add/remove set and makes no changes to etcd. (#10)
 - Health and readiness HTTP endpoints (`http.enabled`, `http.listen_addr`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,18 @@ When two containers want the same DNS name:
 ### Config
 
 Config is handled by Viper in `internal/config/config.go`. The etcd connection takes `endpoints` as a `[]string` (e.g., `["http://etcd:2379"]`). `app.hostname` must be unique per node — it's used to scope ownership of etcd records.
+
+## Versioning, branches & releases
+
+See `CONTRIBUTING.md` for the full contributor guide. Key conventions:
+
+- **Versioning:** [SemVer](https://semver.org/); active line is **0.7.x**. Record changes in `CHANGELOG.md` (Keep a Changelog) under `## [Unreleased]` in the same PR.
+- **Branches:** `main` is the default/stable branch. Each release is integrated on a release branch named `vMAJOR.MINOR.PATCH` (e.g. `v0.7.0`); open PRs against the **active release branch**, not `main`. The release branch later merges into `main` and is tagged.
+- **Tags & releases:** pushing a tag `vMAJOR.MINOR.PATCH` (pre-release: `vMAJOR.MINOR.PATCH-SUFFIX`) triggers `.github/workflows/docker.yaml`, which builds/pushes the GHCR image and cuts a GitHub Release from the matching `## [MAJOR.MINOR.PATCH]` CHANGELOG section. Rename `## [Unreleased]` to the versioned heading before tagging.
+
+## Pull request conventions
+
+- Target the active release branch (`vMAJOR.MINOR.PATCH`), not `main`.
+- Link issues with closing keywords in the PR body — `Closes #N` / `Fixes #N` / `Resolves #N`. Merging to `main` auto-closes them; merging to a release branch (`v*`) labels them `awaiting-release` via `.github/workflows/awaiting-release.yaml`.
+- **Issue state** encodes pipeline position: open without `awaiting-release` = open for development; open + `awaiting-release` = merged to a release branch, not yet released; closed = released.
+- Keep changes covered by tests (`go test -race ./...`), run `make lint`/`make format`, and update `CHANGELOG.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Thanks for contributing to `docker-coredns-sync`. This guide documents the
+project's conventions for versioning, branches, tags, issues, and pull requests.
+
+> Licensing note: this project uses a [custom MIT-NC license](./LICENSE)
+> (non-commercial). By contributing you agree your contributions are licensed
+> under the same terms.
+
+## Development quickstart
+
+```bash
+go build ./cmd/docker-coredns-sync/...   # build
+make test                                 # or: go test ./...
+make test-race                            # race detector
+make lint                                 # golangci-lint
+make format                               # go fmt + goimports
+```
+
+Docker and etcd are mocked in tests, so no external services are required. See
+`CLAUDE.md` for an architecture overview and `TESTS.md` for manual integration
+cases.
+
+## Versioning
+
+- The project follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+- The active version line is **0.7.x**, continuing from the pre-migration
+  **0.6.x** history. See the versioning note at the top of `CHANGELOG.md` for
+  the full history.
+- All notable changes are recorded in `CHANGELOG.md` following
+  [Keep a Changelog](https://keepachangelog.com/). Add your entry under the
+  `## [Unreleased]` heading in the same PR as your change.
+
+## Branches
+
+- **`main`** is the default, stable branch.
+- Each release is integrated on a **release branch** named `vMAJOR.MINOR.PATCH`
+  (e.g. `v0.7.0`). Open feature and fix PRs against the **active release
+  branch**, not `main`.
+- When a release branch is ready, it is merged into `main` and tagged (see
+  below). Issues referenced by merged PRs auto-close at that point.
+
+## Tags & releases
+
+- Releases are cut by pushing a git tag:
+  - Stable: `vMAJOR.MINOR.PATCH` (e.g. `v0.7.0`).
+  - Pre-release: `vMAJOR.MINOR.PATCH-SUFFIX` (e.g. `v0.7.0-rc.1`).
+- Pushing a matching tag triggers `.github/workflows/docker.yaml`, which:
+  - builds and pushes the multi-arch image to GHCR, and
+  - creates a GitHub Release with notes extracted from the matching
+    `## [MAJOR.MINOR.PATCH]` section of `CHANGELOG.md`.
+- Stable (non-pre-release) tags also move the `MAJOR`, `MAJOR.MINOR`, and
+  `latest` image tags.
+- Before tagging, rename the `## [Unreleased]` CHANGELOG section to
+  `## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`.
+
+## Issues & labels
+
+Issue state encodes where work is in the release pipeline:
+
+| State | Meaning |
+|-------|---------|
+| Open, no `awaiting-release` label | Open for development |
+| Open + `awaiting-release` | Implemented and merged to a release branch; not yet released |
+| Closed | Released (auto-closed when the release branch merges to `main`) |
+
+Common labels: `bug`, `enhancement`, `documentation`, `awaiting-release`.
+Group issues by their target release using a **milestone** (e.g. `v0.7.0`).
+
+## Pull requests
+
+- **Target the active release branch** (`vMAJOR.MINOR.PATCH`), not `main`.
+- **Link issues with closing keywords** in the PR body: `Closes #N`,
+  `Fixes #N`, or `Resolves #N`. This drives two automations:
+  - merging into `main` auto-closes the referenced issues;
+  - merging into a release branch (`v*`) labels them `awaiting-release` via
+    `.github/workflows/awaiting-release.yaml`.
+- Keep changes covered by tests (`go test -race ./...`) and run `make lint` /
+  `make format` before opening the PR.
+- Update `CHANGELOG.md` under `## [Unreleased]`.


### PR DESCRIPTION
## Summary

Automates the `awaiting-release` labeling convention and documents the project's versioning/branch/tag/PR conventions so they're discoverable and consistently followed.

### Automation
- `.github/workflows/awaiting-release.yaml`: when a PR merges into a release branch (`v*`), parse its `Closes/Fixes/Resolves #N` references and label those issues `awaiting-release` (issues stay open; they auto-close when the release branch merges to `main`). Creates the label (amber, described) if missing.

### Docs
- **`CONTRIBUTING.md`** — authoritative contributor guide: SemVer (active 0.7.x line), release branches `vMAJOR.MINOR.PATCH`, tag-driven releases via `docker.yaml`, the issue/label lifecycle, and the closing-keyword PR convention.
- **`CLAUDE.md` / `AGENTS.md`** — mirrored "Versioning, branches & releases" and "Pull request conventions" sections so both agent guides stay in parity.
- **`.github/pull_request_template.md`** — reinforces the `Closes #N` convention and the release-branch target.

## Behavior notes
- The workflow uses `pull_request` (not `pull_request_target`), so it runs from the release branch's own workflow file with an `issues: write` token. It governs PRs whose merge includes it — i.e. it takes effect for PRs into `v0.7.0` once this PR is merged. Fork-originated PRs get a read-only token and are skipped (not a concern for this maintainer-merge flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)