### PR TITLE
feat: v0.7.0 P3 issues — per-record TTL, cross-host orphan GC, startup warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Per-record TTL control.** Records can now carry a TTL: set a global default
+  with `app.record_ttl` (seconds) or override per record with a
+  `coredns.<kind>[.<alias>].ttl` label. `0` leaves the TTL unset so CoreDNS
+  applies its own default. A TTL change is treated as record drift, so it
+  self-heals on the next reconcile.
+- **Cross-host garbage collection of orphaned records.** Each host publishes a
+  lease-backed heartbeat key (outside `etcd.path_prefix`) and keeps it alive.
+  Reconciliation now removes records owned by a host that has no live heartbeat,
+  cleaning up after permanently-decommissioned nodes. The lease TTL
+  (`app.heartbeat_ttl`, default `30s`) acts as the grace period so transient
+  outages don't trigger premature deletion. Set it to `0` to disable heartbeats
+  and cross-host GC (preserving the prior, owner-only removal behavior).
+- **Prominent startup warning** when `app.host_ipv4`/`app.host_ipv6` is unset,
+  making it obvious that value-less A/AAAA records will be skipped.
+
+### Notes
+- When upgrading a multi-host fleet, roll out to all hosts together: a host
+  running an older version won't publish a heartbeat and could be treated as
+  dead by upgraded hosts.
+
 ## [0.6.1] - 2026-06-17
 
 Maintenance release. No functional or configuration changes — the application's

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 - Multiple domain support per container
 - Prevents CNAME cycles
 - Automatically removes stale records
+- **Per-record TTL** control via config default or label override
+- **Multi-host aware**: each host publishes a liveness heartbeat and garbage-collects records left behind by hosts that are permanently gone
 - Graceful shutdown support
 - Flexible configuration via **flags**, **env vars**, and **config file**
 - Supports both **YAML** and **JSON** config formats
@@ -51,7 +53,12 @@ coredns.cname.app.value=target.example.com
 ### Optional
 
 - `coredns.force=true` — Force registration for all records in the container
-- `coredns.a.name.force=true` — Force a specific A record
+- `coredns.a.force=true` — Force a specific A record
+- `coredns.a.ttl=300` — Per-record TTL in seconds. Overrides the `app.record_ttl`
+  default. For aliased records use `coredns.a.<alias>.ttl` (e.g.
+  `coredns.a.proxy.ttl=60`). A non-numeric value is ignored. When neither a
+  label nor `app.record_ttl` sets a TTL, the field is omitted and CoreDNS
+  applies its own default.
 
 ---
 
@@ -97,12 +104,37 @@ Configuration values can be provided via:
 | `--app.host-ip` | `app.host_ip` | `DOCKER_COREDNS_SYNC_APP_HOST_IP` | `string` | `"127.0.0.1"` | IP to use for A records |
 | `--app.hostname` | `app.hostname` | `DOCKER_COREDNS_SYNC_APP_HOSTNAME` | `string` | `"your-hostname"` | Unique logical hostname for this node |
 | `--app.poll-interval` | `app.poll_interval` | `DOCKER_COREDNS_SYNC_APP_POLL_INTERVAL` | `int` | `5` | How often to reconcile the registry (in seconds) |
+| `--app.record-ttl` | `app.record_ttl` | `DOCKER_COREDNS_SYNC_APP_RECORD_TTL` | `uint` | `0` | Default DNS record TTL in seconds (`0` = unset; CoreDNS uses its own default). Overridable per record via a `coredns.<kind>[.<alias>].ttl` label |
+| `--app.heartbeat-ttl` | `app.heartbeat_ttl` | `DOCKER_COREDNS_SYNC_APP_HEARTBEAT_TTL` | `int` | `30` | Lease TTL (seconds) for this host's liveness key. Doubles as the grace period before another host garbage-collects records owned by a host that stopped renewing. `0` or negative disables heartbeats **and** cross-host GC |
 | *(config file only)* | `etcd.endpoints` | `DOCKER_COREDNS_SYNC_ETCD_ENDPOINTS` | `[]string` | `["http://localhost:2379"]` | etcd endpoint URLs (supports multiple for cluster) |
 | `--etcd.path-prefix` | `etcd.path_prefix` | `DOCKER_COREDNS_SYNC_ETCD_PATH_PREFIX` | `string` | `"/skydns"` | etcd base path |
 | `--etcd.lock-ttl` | `etcd.lock_ttl` | `DOCKER_COREDNS_SYNC_ETCD_LOCK_TTL` | `float` | `5.0` | Lock lease time-to-live in seconds |
 | `--etcd.lock-timeout` | `etcd.lock_timeout` | `DOCKER_COREDNS_SYNC_ETCD_LOCK_TIMEOUT` | `float` | `2.0` | Lock acquisition timeout |
 | `--etcd.lock-retry-interval` | `etcd.lock_retry_interval` | `DOCKER_COREDNS_SYNC_ETCD_LOCK_RETRY_INTERVAL` | `float` | `0.1` | Retry interval for lock acquisition |
 | `--log.level` | `log.level` | `DOCKER_COREDNS_SYNC_LOG_LEVEL` | `string` | `"INFO"` | Logging level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`) |
+
+---
+
+## Multi-host Behavior & Record Garbage Collection
+
+Each instance scopes ownership of etcd records by its `app.hostname`. A host only
+removes records it owns — except for orphan cleanup described below.
+
+While running, every instance publishes a lease-backed **heartbeat** key (outside
+`etcd.path_prefix`, so CoreDNS never sees it) and keeps it alive. The lease TTL is
+`app.heartbeat_ttl`. During reconciliation a host treats any record whose owner has
+**no live heartbeat** as an orphan and garbage-collects it. The heartbeat lease TTL
+is the grace period: a host must be silent for longer than `heartbeat_ttl` before its
+records become eligible for removal, so a brief outage or restart will **not** cause
+another host to delete its records.
+
+Setting `app.heartbeat_ttl` to `0` (or a negative value) disables both the heartbeat
+and cross-host GC, restoring the original conservative behavior (a host only ever
+removes its own stale records).
+
+> **Upgrading a multi-host fleet:** roll out this version to all hosts together. A host
+> running an older version that doesn't publish a heartbeat will look "dead" to upgraded
+> hosts, which would then GC its records.
 
 ---
 
@@ -131,6 +163,8 @@ app:
   host_ipv6: fd20:0:1::100
   hostname: homeserver
   poll_interval: 5
+  record_ttl: 0      # 0 = let CoreDNS apply its default; override per record with a .ttl label
+  heartbeat_ttl: 30  # liveness lease + cross-host GC grace period; 0 disables
 
 log:
   level: INFO

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -58,7 +58,7 @@ func NewWithFactories(cfg *config.Config, logger zerolog.Logger, factories Clien
 		return nil, fmt.Errorf("failed to connect to etcd: %w", err)
 	}
 
-	reg := registry.NewEtcdRegistry(etcdClient, &cfg.Etcd, cfg.App.Hostname, logger)
+	reg := registry.NewEtcdRegistry(etcdClient, &cfg.Etcd, cfg.App.Hostname, cfg.App.HeartbeatTTL, logger)
 	memState := state.NewMemoryState()
 	engine := core.NewSyncEngine(logger, &cfg.App, gen, reg, memState)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,15 @@ type AppConfig struct {
 	HostIPv6          string `mapstructure:"host_ipv6"`
 	Hostname          string `mapstructure:"hostname"`
 	PollInterval      int    `mapstructure:"poll_interval"`
+	// RecordTTL is the default DNS record TTL in seconds. Zero means "unset"
+	// (the ttl field is omitted from the etcd value and CoreDNS applies its
+	// own default). A per-record `coredns.<kind>[.<alias>].ttl` label overrides it.
+	RecordTTL uint32 `mapstructure:"record_ttl"`
+	// HeartbeatTTL is the lease TTL in seconds for this host's liveness key.
+	// It doubles as the grace period before another host may garbage-collect
+	// records owned by a host that has stopped renewing. Zero (or negative)
+	// disables heartbeats and cross-host GC entirely.
+	HeartbeatTTL int `mapstructure:"heartbeat_ttl"`
 }
 
 // EtcdConfig holds etcd-related configuration.
@@ -87,6 +96,8 @@ func initConfig() error {
 	viper.SetDefault("app.host_ipv6", "")
 	viper.SetDefault("app.hostname", "")
 	viper.SetDefault("app.poll_interval", 5)
+	viper.SetDefault("app.record_ttl", 0)
+	viper.SetDefault("app.heartbeat_ttl", 30)
 	viper.SetDefault("etcd.endpoints", []string{"http://localhost:2379"})
 	viper.SetDefault("etcd.path_prefix", "/skydns")
 	viper.SetDefault("etcd.lock_ttl", 5.0)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -506,6 +506,12 @@ func TestLoad_Success_NoConfigFile_UsesDefaults(t *testing.T) {
 	if cfg.App.PollInterval != 5 {
 		t.Errorf("expected default poll interval 5, got %d", cfg.App.PollInterval)
 	}
+	if cfg.App.RecordTTL != 0 {
+		t.Errorf("expected default record_ttl 0, got %d", cfg.App.RecordTTL)
+	}
+	if cfg.App.HeartbeatTTL != 30 {
+		t.Errorf("expected default heartbeat_ttl 30, got %d", cfg.App.HeartbeatTTL)
+	}
 }
 
 func TestLoad_InitConfigError_InvalidYAML(t *testing.T) {

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -51,6 +51,21 @@ func (se *SyncEngine) handleEvent(evt domain.ContainerEvent) {
 func (se *SyncEngine) Run(ctx context.Context) error {
 	se.logger.Info().Msg("Starting SyncEngine")
 
+	// Surface configuration that will silently drop records, prominently, once
+	// at startup rather than only as per-record warnings buried in the logs.
+	if se.cfg.HostIPv4 == "" {
+		se.logger.Warn().Msg("app.host_ipv4 is not set: value-less A records (coredns.A.<name> with no .value) will be SKIPPED")
+	}
+	if se.cfg.HostIPv6 == "" {
+		se.logger.Warn().Msg("app.host_ipv6 is not set: value-less AAAA records (coredns.AAAA.<name> with no .value) will be SKIPPED")
+	}
+
+	// Publish this host's liveness key so other hosts won't GC our records, and
+	// so we participate in cross-host GC of records owned by dead hosts.
+	if err := se.reg.StartHeartbeat(ctx); err != nil {
+		se.logger.Error().Err(err).Msg("failed to start heartbeat; cross-host GC will be disabled this run")
+	}
+
 	// Step 1: Subscribe to Docker events
 	eventCh, err := se.gen.Subscribe(ctx)
 	if err != nil {
@@ -88,10 +103,17 @@ func (se *SyncEngine) Run(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("error listing registry records: %w", err)
 				}
+				// Live host set drives cross-host GC. On error, fall back to nil
+				// (GC disabled this tick) rather than risk deleting live records.
+				liveHosts, err := se.reg.GetLiveHostnames(ctx)
+				if err != nil {
+					se.logger.Warn().Err(err).Msg("could not fetch live hostnames; skipping cross-host GC this tick")
+					liveHosts = nil
+				}
 				desired := se.state.GetAllDesiredRecordIntents()
 				// Filter out any internally inconsistent intents:
 				desiredReconciled := FilterRecordIntents(desired, se.logger)
-				toAdd, toRemove := ReconcileAndValidate(desiredReconciled, actual, se.cfg, se.logger)
+				toAdd, toRemove := ReconcileAndValidate(desiredReconciled, actual, se.cfg, liveHosts, se.logger)
 				for _, rec := range toRemove {
 					if err := se.reg.Remove(ctx, rec); err != nil {
 						se.logger.Error().Err(err).Msg("Error removing record")

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -733,3 +733,139 @@ func TestSyncEngine_Run_EventChannelClosed(t *testing.T) {
 	// Should continue running even after event channel closes
 	// until context is cancelled
 }
+
+func TestSyncEngine_Run_StartsHeartbeat(t *testing.T) {
+	eventCh := make(chan domain.ContainerEvent)
+	close(eventCh)
+
+	gen := &mockGenerator{
+		subscribeFunc: func(ctx context.Context) (<-chan domain.ContainerEvent, error) {
+			return eventCh, nil
+		},
+	}
+	state := &mockState{
+		getAllDesiredFunc: func() []*domain.RecordIntent {
+			return []*domain.RecordIntent{}
+		},
+	}
+	reg := &mockRegistry{}
+	cfg := testAppConfig()
+	cfg.PollInterval = 10
+
+	engine := NewSyncEngine(engineTestLogger(), cfg, gen, reg, state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	engine.Run(ctx)
+
+	reg.mu.Lock()
+	called := reg.startHeartbeatCalled
+	reg.mu.Unlock()
+	if !called {
+		t.Error("expected StartHeartbeat to be called on Run")
+	}
+}
+
+func TestSyncEngine_Run_GCsOrphanedRecords(t *testing.T) {
+	eventCh := make(chan domain.ContainerEvent)
+	close(eventCh)
+
+	gen := &mockGenerator{
+		subscribeFunc: func(ctx context.Context) (<-chan domain.ContainerEvent, error) {
+			return eventCh, nil
+		},
+	}
+	state := &mockState{
+		getAllDesiredFunc: func() []*domain.RecordIntent {
+			return []*domain.RecordIntent{} // we desire nothing
+		},
+	}
+
+	rec, _ := domain.NewA("ghost.example.com", "192.168.1.9")
+	orphan := &domain.RecordIntent{
+		ContainerId:   "dead-container",
+		ContainerName: "dead-app",
+		Created:       time.Now().Add(-time.Hour),
+		Hostname:      "dead-host", // owner not in live set
+		Record:        rec,
+	}
+
+	reg := &mockRegistry{
+		listFunc: func(ctx context.Context) ([]*domain.RecordIntent, error) {
+			return []*domain.RecordIntent{orphan}, nil
+		},
+		getLiveHostnamesFunc: func(ctx context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{"test-host": {}}, nil // dead-host absent
+		},
+	}
+	cfg := testAppConfig()
+	cfg.PollInterval = 1
+
+	engine := NewSyncEngine(engineTestLogger(), cfg, gen, reg, state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	go func() { engine.Run(ctx) }()
+	time.Sleep(1200 * time.Millisecond)
+	cancel()
+
+	if !reg.WasRemoveCalled() {
+		t.Fatal("expected orphaned record to be removed via cross-host GC")
+	}
+	removed := reg.GetRemovedRecords()
+	if len(removed) != 1 || removed[0].Hostname != "dead-host" {
+		t.Errorf("expected exactly the dead-host record removed, got %+v", removed)
+	}
+}
+
+func TestSyncEngine_Run_GetLiveHostnamesError(t *testing.T) {
+	eventCh := make(chan domain.ContainerEvent)
+	close(eventCh)
+
+	gen := &mockGenerator{
+		subscribeFunc: func(ctx context.Context) (<-chan domain.ContainerEvent, error) {
+			return eventCh, nil
+		},
+	}
+	state := &mockState{
+		getAllDesiredFunc: func() []*domain.RecordIntent {
+			return []*domain.RecordIntent{}
+		},
+	}
+
+	rec, _ := domain.NewA("ghost.example.com", "192.168.1.9")
+	orphan := &domain.RecordIntent{
+		ContainerId:   "dead-container",
+		ContainerName: "dead-app",
+		Created:       time.Now().Add(-time.Hour),
+		Hostname:      "dead-host",
+		Record:        rec,
+	}
+
+	reg := &mockRegistry{
+		listFunc: func(ctx context.Context) ([]*domain.RecordIntent, error) {
+			return []*domain.RecordIntent{orphan}, nil
+		},
+		getLiveHostnamesFunc: func(ctx context.Context) (map[string]struct{}, error) {
+			return nil, errors.New("etcd unavailable")
+		},
+	}
+	cfg := testAppConfig()
+	cfg.PollInterval = 1
+
+	engine := NewSyncEngine(engineTestLogger(), cfg, gen, reg, state)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	go func() { engine.Run(ctx) }()
+	time.Sleep(1200 * time.Millisecond)
+	cancel()
+
+	// On liveHosts error, GC must be skipped: the foreign record stays.
+	if reg.WasRemoveCalled() {
+		t.Error("expected no removals when GetLiveHostnames fails (GC disabled this tick)")
+	}
+}

--- a/internal/core/interface.go
+++ b/internal/core/interface.go
@@ -18,6 +18,8 @@ type state interface {
 }
 
 type upstreamRegistry interface {
+	StartHeartbeat(ctx context.Context) error
+	GetLiveHostnames(ctx context.Context) (map[string]struct{}, error)
 	LockTransaction(ctx context.Context, key []string, fn func() error) error
 	List(ctx context.Context) ([]*domain.RecordIntent, error)
 	Register(ctx context.Context, record *domain.RecordIntent) error

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/auto-dns/docker-coredns-sync/internal/domain"
@@ -11,9 +12,10 @@ type LabeledRecord struct {
 	prefix string
 	Kind   domain.RecordKind // A, AAAA, CNAME
 	Name   string
-	Value  string // may be empty for A (defaults)
-	Alias  string // optional
-	Force  *bool  // Force is tri-state: nil = not specified on the record label, non-nil = explicit value
+	Value  string  // may be empty for A (defaults)
+	Alias  string  // optional
+	Force  *bool   // Force is tri-state: nil = not specified on the record label, non-nil = explicit value
+	TTL    *uint32 // TTL is tri-state: nil = not specified on the record label, non-nil = explicit override
 }
 
 func (lr LabeledRecord) GetNameLabel() string {
@@ -59,6 +61,7 @@ func ParseLabels(prefix string, labels map[string]string) ParsedLabels {
 		name  string
 		value string
 		force *bool
+		ttl   *uint32
 	}
 
 	aggregations := map[string]*aggregation{}
@@ -93,7 +96,7 @@ func ParseLabels(prefix string, labels map[string]string) ParsedLabels {
 		}
 
 		field := parts[keyIdx]
-		if field != "name" && field != "value" && field != "force" {
+		if field != "name" && field != "value" && field != "force" && field != "ttl" {
 			continue
 		}
 
@@ -112,6 +115,10 @@ func ParseLabels(prefix string, labels map[string]string) ParsedLabels {
 		case "force":
 			force := boolFromLabel(v)
 			a.force = &force
+		case "ttl":
+			if ttl, ok := ttlFromLabel(v); ok {
+				a.ttl = &ttl
+			}
 		}
 	}
 
@@ -124,6 +131,7 @@ func ParseLabels(prefix string, labels map[string]string) ParsedLabels {
 			Value:  a.value, // may be empty; caller decides fallback (e.g., host IP for A)
 			Alias:  a.alias,
 			Force:  a.force,
+			TTL:    a.ttl,
 		})
 	}
 
@@ -131,3 +139,13 @@ func ParseLabels(prefix string, labels map[string]string) ParsedLabels {
 }
 
 func boolFromLabel(v string) bool { return strings.EqualFold(strings.TrimSpace(v), "true") }
+
+// ttlFromLabel parses a TTL label value (seconds). It returns ok=false for
+// blank or non-numeric values so a bad label is ignored rather than applied.
+func ttlFromLabel(v string) (uint32, bool) {
+	n, err := strconv.ParseUint(strings.TrimSpace(v), 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(n), true
+}

--- a/internal/core/labels_test.go
+++ b/internal/core/labels_test.go
@@ -250,6 +250,86 @@ func TestParseLabels_MultipleAliases(t *testing.T) {
 	}
 }
 
+func TestParseLabels_RecordLevelTTL(t *testing.T) {
+	labels := map[string]string{
+		"coredns.enabled": "true",
+		"coredns.A.name":  "app.example.com",
+		"coredns.A.value": "192.168.1.1",
+		"coredns.A.ttl":   "300",
+	}
+
+	result := ParseLabels("coredns", labels)
+
+	if len(result.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(result.Records))
+	}
+	rec := result.Records[0]
+	if rec.TTL == nil {
+		t.Fatal("expected TTL to be set")
+	}
+	if *rec.TTL != 300 {
+		t.Errorf("expected TTL 300, got %d", *rec.TTL)
+	}
+}
+
+func TestParseLabels_RecordLevelTTLWithAlias(t *testing.T) {
+	labels := map[string]string{
+		"coredns.enabled":     "true",
+		"coredns.A.web.name":  "web.example.com",
+		"coredns.A.web.value": "192.168.1.1",
+		"coredns.A.web.ttl":   "60",
+	}
+
+	result := ParseLabels("coredns", labels)
+
+	if len(result.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(result.Records))
+	}
+	rec := result.Records[0]
+	if rec.TTL == nil || *rec.TTL != 60 {
+		t.Errorf("expected TTL 60, got %v", rec.TTL)
+	}
+}
+
+func TestParseLabels_TTLNotSetIsNil(t *testing.T) {
+	labels := map[string]string{
+		"coredns.enabled": "true",
+		"coredns.A.name":  "app.example.com",
+		"coredns.A.value": "192.168.1.1",
+	}
+
+	result := ParseLabels("coredns", labels)
+
+	if len(result.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(result.Records))
+	}
+	if result.Records[0].TTL != nil {
+		t.Errorf("expected TTL to be nil when unspecified, got %v", *result.Records[0].TTL)
+	}
+}
+
+func TestParseLabels_InvalidTTLIgnored(t *testing.T) {
+	for _, val := range []string{"abc", "-5", "3.5", ""} {
+		t.Run(val, func(t *testing.T) {
+			labels := map[string]string{
+				"coredns.enabled": "true",
+				"coredns.A.name":  "app.example.com",
+				"coredns.A.value": "192.168.1.1",
+				"coredns.A.ttl":   val,
+			}
+
+			result := ParseLabels("coredns", labels)
+
+			if len(result.Records) != 1 {
+				t.Fatalf("expected 1 record, got %d", len(result.Records))
+			}
+			if result.Records[0].TTL != nil {
+				t.Errorf("expected invalid TTL %q to be ignored (nil), got %v", val, *result.Records[0].TTL)
+			}
+		})
+	}
+}
+
 func TestParseLabels_RecordLevelForce(t *testing.T) {
 	labels := map[string]string{
 		"coredns.enabled":       "true",

--- a/internal/core/mock_test.go
+++ b/internal/core/mock_test.go
@@ -92,21 +92,47 @@ func (m *mockState) WasMarkRemovedCalled() bool {
 }
 
 type mockRegistry struct {
-	mu                  sync.Mutex
-	lockTransactionFunc func(ctx context.Context, keys []string, fn func() error) error
-	listFunc            func(ctx context.Context) ([]*domain.RecordIntent, error)
-	registerFunc        func(ctx context.Context, record *domain.RecordIntent) error
-	removeFunc          func(ctx context.Context, record *domain.RecordIntent) error
-	closeFunc           func() error
+	mu                   sync.Mutex
+	startHeartbeatFunc   func(ctx context.Context) error
+	getLiveHostnamesFunc func(ctx context.Context) (map[string]struct{}, error)
+	lockTransactionFunc  func(ctx context.Context, keys []string, fn func() error) error
+	listFunc             func(ctx context.Context) ([]*domain.RecordIntent, error)
+	registerFunc         func(ctx context.Context, record *domain.RecordIntent) error
+	removeFunc           func(ctx context.Context, record *domain.RecordIntent) error
+	closeFunc            func() error
 
-	lockTransactionCalled bool
-	listCalled            bool
-	registerCalled        bool
-	removeCalled          bool
-	closeCalled           bool
+	startHeartbeatCalled   bool
+	getLiveHostnamesCalled bool
+	lockTransactionCalled  bool
+	listCalled             bool
+	registerCalled         bool
+	removeCalled           bool
+	closeCalled            bool
 
 	registeredRecords []*domain.RecordIntent
 	removedRecords    []*domain.RecordIntent
+}
+
+func (m *mockRegistry) StartHeartbeat(ctx context.Context) error {
+	m.mu.Lock()
+	m.startHeartbeatCalled = true
+	m.mu.Unlock()
+
+	if m.startHeartbeatFunc != nil {
+		return m.startHeartbeatFunc(ctx)
+	}
+	return nil
+}
+
+func (m *mockRegistry) GetLiveHostnames(ctx context.Context) (map[string]struct{}, error) {
+	m.mu.Lock()
+	m.getLiveHostnamesCalled = true
+	m.mu.Unlock()
+
+	if m.getLiveHostnamesFunc != nil {
+		return m.getLiveHostnamesFunc(ctx)
+	}
+	return nil, nil
 }
 
 func (m *mockRegistry) LockTransaction(ctx context.Context, keys []string, fn func() error) error {

--- a/internal/core/reconciliation.go
+++ b/internal/core/reconciliation.go
@@ -172,7 +172,15 @@ func FilterRecordIntents(recordIntents []*domain.RecordIntent, logger zerolog.Lo
 	return desiredByNameKindDeduplicated.GetAllValues()
 }
 
-func ReconcileAndValidate(desired, actual []*domain.RecordIntent, cfg *config.AppConfig, logger zerolog.Logger) ([]*domain.RecordIntent, []*domain.RecordIntent) {
+// ReconcileAndValidate compares the desired record set against what is actually
+// in etcd and returns the records to add and to remove.
+//
+// liveHostnames is the set of hosts known to be alive (via their heartbeat
+// keys). When it is non-nil, records owned by a host that is NOT in the set
+// (and not owned by this host) are garbage-collected as orphans. When it is
+// nil, cross-host GC is disabled and only this host's own stale records are
+// removed — the original, conservative behavior.
+func ReconcileAndValidate(desired, actual []*domain.RecordIntent, cfg *config.AppConfig, liveHostnames map[string]struct{}, logger zerolog.Logger) ([]*domain.RecordIntent, []*domain.RecordIntent) {
 	toAddMap := map[string]*domain.RecordIntent{}
 	toRemoveMap := map[string]*domain.RecordIntent{}
 
@@ -189,6 +197,13 @@ func ReconcileAndValidate(desired, actual []*domain.RecordIntent, cfg *config.Ap
 				logger.Info().Msgf("Removing stale record: %s (owned by %s/%s)", ri.Record.Render(), ri.Hostname, ri.ContainerName)
 				toRemoveMap[ri.Key()] = ri
 				continue // Don't add stale records to lookup - they're already being removed
+			} else if liveHostnames != nil {
+				if _, alive := liveHostnames[ri.Hostname]; !alive {
+					logger.Info().Msgf("GC: removing orphaned record owned by dead host: %s (owned by %s/%s)", ri.Record.Render(), ri.Hostname, ri.ContainerName)
+					toRemoveMap[ri.Key()] = ri
+					continue // Don't add orphaned records to lookup - they're already being removed
+				}
+				logger.Debug().Msgf("Skipping removal of record %s owned by live host %s (not this host %s)", ri.Record.Render(), ri.Hostname, cfg.Hostname)
 			} else {
 				logger.Debug().Msgf("Skipping removal of record %s not owned by this host (%s != %s)", ri.Record.Render(), ri.Hostname, cfg.Hostname)
 			}

--- a/internal/core/reconciliation_test.go
+++ b/internal/core/reconciliation_test.go
@@ -314,7 +314,7 @@ func TestReconcileAndValidate_AddNewRecord(t *testing.T) {
 	}
 	actual := []*domain.RecordIntent{}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 1 {
 		t.Errorf("expected 1 record to add, got %d", len(toAdd))
@@ -331,7 +331,7 @@ func TestReconcileAndValidate_RemoveStaleOwned(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c1", time.Now(), false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 0 {
 		t.Errorf("expected 0 records to add, got %d", len(toAdd))
@@ -348,7 +348,7 @@ func TestReconcileAndValidate_KeepStaleNotOwned(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c1", time.Now(), false, "other-host"), // different host
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 0 {
 		t.Errorf("expected 0 records to add, got %d", len(toAdd))
@@ -364,7 +364,7 @@ func TestReconcileAndValidate_IdenticalNoOp(t *testing.T) {
 	desired := []*domain.RecordIntent{intent}
 	actual := []*domain.RecordIntent{intent}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 0 {
 		t.Errorf("expected 0 records to add, got %d", len(toAdd))
@@ -384,7 +384,7 @@ func TestReconcileAndValidate_EvictCNAMEForA(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 1 {
 		t.Errorf("expected 1 record to add, got %d", len(toAdd))
@@ -404,7 +404,7 @@ func TestReconcileAndValidate_ForceEviction(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c2", now.Add(-5*time.Hour), false, "test-host"),
 	}
 
-	toAdd, _ := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, _ := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Force should cause eviction of different record with same name+kind+value
 	if len(toAdd) != 1 {
@@ -421,7 +421,7 @@ func TestReconcileAndValidate_ValidationFailureSkipped(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c2", time.Now().Add(-10*time.Hour), false, "other-host"), // other host, won't be evicted
 	}
 
-	toAdd, _ := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, _ := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// CNAME conflicts with A record that can't be evicted (different host)
 	if len(toAdd) != 0 {
@@ -445,7 +445,7 @@ func TestReconcileAndValidate_ComplexScenario(t *testing.T) {
 		makeRecordIntent("other.example.com", domain.RecordA, "192.168.1.100", "c5", now, false, "other-host"), // not owned
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Should add: app1, alias
 	// Should remove: stale (owned, not in desired)
@@ -555,7 +555,7 @@ func TestReconcileAndValidate_AAAAVsCNAME_AAAAWins(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 1 {
 		t.Errorf("expected 1 AAAA record to add, got %d", len(toAdd))
@@ -576,7 +576,7 @@ func TestReconcileAndValidate_AAAAVsCNAME_CNAMEWins(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, _ := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, _ := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// CNAME is older and owned by another host, AAAA should not be added
 	if len(toAdd) != 0 {
@@ -594,7 +594,7 @@ func TestReconcileAndValidate_AAAAVsAAAA_SameValue(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c1", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Same record - no changes
 	if len(toAdd) != 0 {
@@ -615,7 +615,7 @@ func TestReconcileAndValidate_AAAAVsAAAA_DifferentOwner(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c2", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Older desired wins
 	if len(toAdd) != 1 {
@@ -637,7 +637,7 @@ func TestReconcileAndValidate_CNAMEVsAAndAAAA(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c3", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// CNAME with force should evict both A and AAAA
 	if len(toAdd) != 1 {
@@ -658,7 +658,7 @@ func TestReconcileAndValidate_CNAMEVsCNAME_Eviction(t *testing.T) {
 		makeRecordIntent("alias.example.com", domain.RecordCNAME, "old-target.example.com", "c2", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Force CNAME should replace existing CNAME
 	if len(toAdd) != 1 {
@@ -676,7 +676,7 @@ func TestReconcileAndValidate_CNAMEVsCNAME_IdenticalNoOp(t *testing.T) {
 	desired := []*domain.RecordIntent{intent}
 	actual := []*domain.RecordIntent{intent}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 0 {
 		t.Errorf("expected 0 records to add, got %d", len(toAdd))
@@ -696,7 +696,7 @@ func TestReconcileAndValidate_AVsA_ForceEviction(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.2", "c2", now.Add(-5*time.Hour), false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	if len(toAdd) != 1 {
 		t.Errorf("expected 1 record to add, got %d", len(toAdd))
@@ -718,7 +718,7 @@ func TestReconcileAndValidate_MultipleDesiredWithEvictions(t *testing.T) {
 		makeRecordIntent("app2.example.com", domain.RecordCNAME, "old2.example.com", "c4", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Both A records should win over CNAMEs (older)
 	if len(toAdd) != 2 {
@@ -880,7 +880,7 @@ func TestReconcileAndValidate_AVsA_NewerALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.2", "c2", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Existing A is older but owned by other host - desired newer should NOT win
 	if len(toAdd) != 0 {
@@ -902,7 +902,7 @@ func TestReconcileAndValidate_AAAAVsAAAA_NewerAAAALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c2", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Existing AAAA is older but owned by other host - desired newer should NOT win
 	if len(toAdd) != 0 {
@@ -924,7 +924,7 @@ func TestReconcileAndValidate_AVsCNAME_ALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Existing CNAME is older (owned by other host) - A should not be added
 	if len(toAdd) != 0 {
@@ -946,7 +946,7 @@ func TestReconcileAndValidate_CNAMEVsCNAME_NewerCNAMELoses(t *testing.T) {
 		makeRecordIntent("alias.example.com", domain.RecordCNAME, "old-target.example.com", "c2", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Existing CNAME is older (owned by other host) - new CNAME should not be added
 	if len(toAdd) != 0 {
@@ -969,7 +969,7 @@ func TestReconcileAndValidate_CNAMEVsAAndAAAA_CNAMELoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c3", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Existing address records are older (owned by other host) - CNAME should not be added
 	if len(toAdd) != 0 {
@@ -993,7 +993,7 @@ func TestReconcileAndValidate_ValidationFailure(t *testing.T) {
 		makeRecordIntent("loop.example.com", domain.RecordCNAME, "app.example.com", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Should skip the CNAME because it creates a cycle
 	if len(toAdd) != 0 {
@@ -1014,7 +1014,7 @@ func TestReconcileAndValidate_StaleRecordOtherHost(t *testing.T) {
 		makeRecordIntent("stale.example.com", domain.RecordA, "192.168.1.99", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Should not remove record owned by other host
 	if len(toRemove) != 0 {
@@ -1038,7 +1038,7 @@ func TestReconcileAndValidate_AWithDifferentValue(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c2", now.Add(-5*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Should add new A - different values can coexist
 	if len(toAdd) != 1 {
@@ -1060,7 +1060,7 @@ func TestReconcileAndValidate_CNAMEOlderThanAllAddress(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c3", now, false, "test-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// CNAME is older than all address records - should evict them
 	if len(toAdd) != 1 {
@@ -1083,7 +1083,7 @@ func TestReconcileAndValidate_CNAMEVsAddressNotOlderThanAll(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c3", now.Add(-10*time.Hour), false, "other-host"), // Older than CNAME
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// CNAME is NOT older than all address records - should not evict
 	if len(toAdd) != 0 {
@@ -1229,7 +1229,7 @@ func TestReconcileAndValidate_CrossHostAVsCNAME_AEvictsCNAME(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// A is older than CNAME and should evict it
 	if len(toAdd) != 1 {
@@ -1251,7 +1251,7 @@ func TestReconcileAndValidate_CrossHostAVsCNAME_ALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now.Add(-10*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// A is newer than CNAME - A loses, no changes
 	if len(toAdd) != 0 {
@@ -1273,7 +1273,7 @@ func TestReconcileAndValidate_CrossHostAAAAVsCNAME_AAAAEvictsCNAME(t *testing.T)
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// AAAA is older than CNAME and should evict it
 	if len(toAdd) != 1 {
@@ -1295,7 +1295,7 @@ func TestReconcileAndValidate_CrossHostAAAAVsCNAME_AAAALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now.Add(-10*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// AAAA is newer than CNAME - AAAA loses
 	if len(toAdd) != 0 {
@@ -1317,7 +1317,7 @@ func TestReconcileAndValidate_CrossHostAVsA_AEvictsA(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Desired A is older, should evict the actual A
 	if len(toAdd) != 1 {
@@ -1339,7 +1339,7 @@ func TestReconcileAndValidate_CrossHostAVsA_ALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordA, "192.168.1.1", "c2", now.Add(-10*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Desired A is newer - it loses to the older actual A
 	if len(toAdd) != 0 {
@@ -1361,7 +1361,7 @@ func TestReconcileAndValidate_CrossHostAAAAVsAAAA_AAAAEvictsAAAA(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Desired AAAA is older, should evict the actual AAAA
 	if len(toAdd) != 1 {
@@ -1383,7 +1383,7 @@ func TestReconcileAndValidate_CrossHostAAAAVsAAAA_AAAALoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c2", now.Add(-10*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Desired AAAA is newer - it loses to the older actual AAAA
 	if len(toAdd) != 0 {
@@ -1406,7 +1406,7 @@ func TestReconcileAndValidate_CrossHostCNAMEVsAAndAAAA_CNAMEEvicts(t *testing.T)
 		makeRecordIntent("app.example.com", domain.RecordAAAA, "2001:db8::1", "c3", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// CNAME is older than all address records, should evict both
 	if len(toAdd) != 1 {
@@ -1428,7 +1428,7 @@ func TestReconcileAndValidate_CrossHostCNAMEVsCNAME_CNAMEEvicts(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target2.example.com", "c2", now, false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Desired CNAME is older, should evict the actual CNAME
 	if len(toAdd) != 1 {
@@ -1450,7 +1450,7 @@ func TestReconcileAndValidate_CrossHostCNAMEVsCNAME_CNAMELoses(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target2.example.com", "c2", now.Add(-10*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Desired CNAME is newer - it loses to the older actual CNAME
 	if len(toAdd) != 0 {
@@ -1472,7 +1472,7 @@ func TestReconcileAndValidate_ForceEvictsCrossHost(t *testing.T) {
 		makeRecordIntent("app.example.com", domain.RecordCNAME, "target.example.com", "c2", now.Add(-10*time.Hour), false, "other-host"),
 	}
 
-	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, reconcileLogger())
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
 
 	// Force should evict even though the actual record is older
 	if len(toAdd) != 1 {
@@ -1480,5 +1480,90 @@ func TestReconcileAndValidate_ForceEvictsCrossHost(t *testing.T) {
 	}
 	if len(toRemove) != 1 {
 		t.Errorf("expected 1 record to remove, got %d", len(toRemove))
+	}
+}
+
+// ============================================================================
+// Cross-host orphan GC tests (heartbeat-driven)
+// ============================================================================
+
+func TestReconcileAndValidate_GCRemovesOrphanFromDeadHost(t *testing.T) {
+	cfg := reconcileConfig() // Hostname: test-host
+	now := time.Now()
+	desired := []*domain.RecordIntent{}
+	// A record owned by a host that is NOT in the live set.
+	actual := []*domain.RecordIntent{
+		makeRecordIntent("ghost.example.com", domain.RecordA, "192.168.1.9", "c1", now.Add(-10*time.Hour), false, "dead-host"),
+	}
+	liveHosts := map[string]struct{}{"test-host": {}} // dead-host absent
+
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, liveHosts, reconcileLogger())
+
+	if len(toAdd) != 0 {
+		t.Errorf("expected 0 records to add, got %d", len(toAdd))
+	}
+	if len(toRemove) != 1 {
+		t.Fatalf("expected 1 orphaned record to remove, got %d", len(toRemove))
+	}
+	if toRemove[0].Hostname != "dead-host" {
+		t.Errorf("expected removed record to be owned by dead-host, got %q", toRemove[0].Hostname)
+	}
+}
+
+func TestReconcileAndValidate_GCKeepsRecordsFromLiveHost(t *testing.T) {
+	cfg := reconcileConfig()
+	now := time.Now()
+	desired := []*domain.RecordIntent{}
+	actual := []*domain.RecordIntent{
+		makeRecordIntent("peer.example.com", domain.RecordA, "192.168.1.8", "c1", now.Add(-10*time.Hour), false, "other-host"),
+	}
+	liveHosts := map[string]struct{}{"test-host": {}, "other-host": {}} // other-host alive
+
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, liveHosts, reconcileLogger())
+
+	if len(toAdd) != 0 {
+		t.Errorf("expected 0 records to add, got %d", len(toAdd))
+	}
+	if len(toRemove) != 0 {
+		t.Errorf("expected 0 records to remove for a live host, got %d", len(toRemove))
+	}
+}
+
+func TestReconcileAndValidate_GCDisabledKeepsForeignRecords(t *testing.T) {
+	cfg := reconcileConfig()
+	now := time.Now()
+	desired := []*domain.RecordIntent{}
+	actual := []*domain.RecordIntent{
+		makeRecordIntent("ghost.example.com", domain.RecordA, "192.168.1.9", "c1", now.Add(-10*time.Hour), false, "dead-host"),
+	}
+
+	// nil liveHosts => cross-host GC disabled; original conservative behavior.
+	toAdd, toRemove := ReconcileAndValidate(desired, actual, cfg, nil, reconcileLogger())
+
+	if len(toAdd) != 0 {
+		t.Errorf("expected 0 records to add, got %d", len(toAdd))
+	}
+	if len(toRemove) != 0 {
+		t.Errorf("expected 0 records to remove when GC disabled, got %d", len(toRemove))
+	}
+}
+
+func TestReconcileAndValidate_GCStillRemovesOwnStaleRecords(t *testing.T) {
+	cfg := reconcileConfig()
+	now := time.Now()
+	desired := []*domain.RecordIntent{}
+	// Our own record, no longer desired -> removed regardless of liveHosts.
+	actual := []*domain.RecordIntent{
+		makeRecordIntent("mine.example.com", domain.RecordA, "10.0.0.1", "c1", now.Add(-time.Hour), false, "test-host"),
+	}
+	liveHosts := map[string]struct{}{"test-host": {}}
+
+	_, toRemove := ReconcileAndValidate(desired, actual, cfg, liveHosts, reconcileLogger())
+
+	if len(toRemove) != 1 {
+		t.Fatalf("expected 1 own stale record to remove, got %d", len(toRemove))
+	}
+	if toRemove[0].Hostname != "test-host" {
+		t.Errorf("expected removed record to be our own, got %q", toRemove[0].Hostname)
 	}
 }

--- a/internal/core/record_builder.go
+++ b/internal/core/record_builder.go
@@ -70,12 +70,20 @@ func GetContainerRecordIntents(event domain.ContainerEvent, cfg *config.AppConfi
 			force = *labeledRecord.Force
 		}
 
+		// TTL: per-record label override wins, otherwise the configured default
+		// (0 = unset; CoreDNS applies its own default).
+		ttl := cfg.RecordTTL
+		if labeledRecord.TTL != nil {
+			ttl = *labeledRecord.TTL
+		}
+
 		intent := &domain.RecordIntent{
 			ContainerId:   event.Container.Id,
 			ContainerName: event.Container.Name,
 			Created:       event.Container.Created,
 			Hostname:      cfg.Hostname,
 			Force:         force,
+			TTL:           ttl,
 			Record:        rec,
 		}
 		intents = append(intents, intent)

--- a/internal/core/record_builder_test.go
+++ b/internal/core/record_builder_test.go
@@ -85,6 +85,63 @@ func TestGetContainerRecordIntents_AWithValue(t *testing.T) {
 	}
 }
 
+func TestGetContainerRecordIntents_TTLDefaultFromConfig(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.RecordTTL = 120
+	event := makeContainerEvent(map[string]string{
+		"coredns.enabled": "true",
+		"coredns.A.name":  "app.example.com",
+		"coredns.A.value": "192.168.1.1",
+	})
+
+	intents := GetContainerRecordIntents(event, cfg, nopLogger())
+
+	if len(intents) != 1 {
+		t.Fatalf("expected 1 intent, got %d", len(intents))
+	}
+	if intents[0].TTL != 120 {
+		t.Errorf("expected TTL 120 from config default, got %d", intents[0].TTL)
+	}
+}
+
+func TestGetContainerRecordIntents_TTLLabelOverridesConfig(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.RecordTTL = 120
+	event := makeContainerEvent(map[string]string{
+		"coredns.enabled": "true",
+		"coredns.A.name":  "app.example.com",
+		"coredns.A.value": "192.168.1.1",
+		"coredns.A.ttl":   "30",
+	})
+
+	intents := GetContainerRecordIntents(event, cfg, nopLogger())
+
+	if len(intents) != 1 {
+		t.Fatalf("expected 1 intent, got %d", len(intents))
+	}
+	if intents[0].TTL != 30 {
+		t.Errorf("expected per-record TTL 30 to override config default, got %d", intents[0].TTL)
+	}
+}
+
+func TestGetContainerRecordIntents_TTLUnsetIsZero(t *testing.T) {
+	cfg := makeTestConfig() // RecordTTL defaults to 0
+	event := makeContainerEvent(map[string]string{
+		"coredns.enabled": "true",
+		"coredns.A.name":  "app.example.com",
+		"coredns.A.value": "192.168.1.1",
+	})
+
+	intents := GetContainerRecordIntents(event, cfg, nopLogger())
+
+	if len(intents) != 1 {
+		t.Fatalf("expected 1 intent, got %d", len(intents))
+	}
+	if intents[0].TTL != 0 {
+		t.Errorf("expected TTL 0 when neither config nor label set it, got %d", intents[0].TTL)
+	}
+}
+
 func TestGetContainerRecordIntents_AWithDefaultIPv4(t *testing.T) {
 	cfg := makeTestConfig()
 	event := makeContainerEvent(map[string]string{

--- a/internal/domain/record_intent.go
+++ b/internal/domain/record_intent.go
@@ -11,11 +11,14 @@ type RecordIntent struct {
 	Created       time.Time
 	Hostname      string
 	Force         bool
-	Record        Record
+	// TTL is the DNS record TTL in seconds. Zero means "unset" — the field is
+	// omitted from the etcd value and CoreDNS applies its own default.
+	TTL    uint32
+	Record Record
 }
 
 func (ri RecordIntent) Render() string {
-	return fmt.Sprintf("%s (container_id=%s, container_name=%s, hostname=%s, created=%s, force=%t)", ri.Record.Render(), ri.ContainerId, ri.ContainerName, ri.Hostname, ri.Created.Format("2006-01-02 15:04:05"), ri.Force)
+	return fmt.Sprintf("%s (container_id=%s, container_name=%s, hostname=%s, created=%s, force=%t, ttl=%d)", ri.Record.Render(), ri.ContainerId, ri.ContainerName, ri.Hostname, ri.Created.Format("2006-01-02 15:04:05"), ri.Force, ri.TTL)
 }
 
 func (ri RecordIntent) Equal(other RecordIntent) bool {
@@ -23,9 +26,10 @@ func (ri RecordIntent) Equal(other RecordIntent) bool {
 		ri.ContainerName == other.ContainerName &&
 		ri.Hostname == other.Hostname &&
 		ri.Force == other.Force &&
+		ri.TTL == other.TTL &&
 		ri.Record.Equal(other.Record)
 }
 
 func (ri RecordIntent) Key() string {
-	return fmt.Sprintf("%s|%s|%s|%t|%s", ri.ContainerId, ri.ContainerName, ri.Hostname, ri.Force, ri.Record.Key())
+	return fmt.Sprintf("%s|%s|%s|%t|%d|%s", ri.ContainerId, ri.ContainerName, ri.Hostname, ri.Force, ri.TTL, ri.Record.Key())
 }

--- a/internal/domain/record_intent_test.go
+++ b/internal/domain/record_intent_test.go
@@ -106,6 +106,46 @@ func TestRecordIntent_Key_SameForIdentical(t *testing.T) {
 	}
 }
 
+func TestRecordIntent_Key_DiffersByTTL(t *testing.T) {
+	now := time.Now()
+	rec, _ := NewA("app.example.com", "192.168.1.1")
+
+	base := RecordIntent{
+		ContainerId:   "container1",
+		ContainerName: "app1",
+		Created:       now,
+		Hostname:      "host1",
+		Force:         false,
+		Record:        rec,
+	}
+	withTTL := base
+	withTTL.TTL = 300
+
+	if base.Key() == withTTL.Key() {
+		t.Errorf("expected keys to differ when TTL differs so a TTL-only change self-heals: %q", base.Key())
+	}
+}
+
+func TestRecordIntent_Equal_DifferentTTL(t *testing.T) {
+	now := time.Now()
+	rec, _ := NewA("app.example.com", "192.168.1.1")
+
+	ri1 := RecordIntent{
+		ContainerId:   "container1",
+		ContainerName: "app1",
+		Created:       now,
+		Hostname:      "host1",
+		Record:        rec,
+		TTL:           60,
+	}
+	ri2 := ri1
+	ri2.TTL = 120
+
+	if ri1.Equal(ri2) {
+		t.Error("expected RecordIntents with different TTL to not be equal")
+	}
+}
+
 func TestRecordIntent_Equal_AllFieldsMatch(t *testing.T) {
 	now := time.Now()
 	rec, _ := NewA("app.example.com", "192.168.1.1")

--- a/internal/registry/etcd_registry.go
+++ b/internal/registry/etcd_registry.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/auto-dns/docker-coredns-sync/internal/config"
@@ -15,20 +16,131 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+// heartbeatPrefix is where per-host liveness keys live. It is deliberately
+// outside the SkyDNS path_prefix so CoreDNS never sees these keys and List()
+// never parses them as DNS records.
+const heartbeatPrefix = "/docker-coredns-sync/heartbeat"
+
 type EtcdRegistry struct {
-	client   etcdClient
-	cfg      *config.EtcdConfig
-	hostname string
-	logger   zerolog.Logger
+	client       etcdClient
+	cfg          *config.EtcdConfig
+	hostname     string
+	heartbeatTTL int
+	logger       zerolog.Logger
+
+	hbMu     sync.Mutex
+	hbLease  clientv3.LeaseID
+	hbCancel context.CancelFunc
 }
 
-func NewEtcdRegistry(client etcdClient, cfg *config.EtcdConfig, hostname string, logger zerolog.Logger) *EtcdRegistry {
+func NewEtcdRegistry(client etcdClient, cfg *config.EtcdConfig, hostname string, heartbeatTTL int, logger zerolog.Logger) *EtcdRegistry {
 	return &EtcdRegistry{
-		client:   client,
-		cfg:      cfg,
-		hostname: hostname,
-		logger:   logger.With().Str("component", "etcd_registry").Logger(),
+		client:       client,
+		cfg:          cfg,
+		hostname:     hostname,
+		heartbeatTTL: heartbeatTTL,
+		logger:       logger.With().Str("component", "etcd_registry").Logger(),
 	}
+}
+
+func heartbeatKey(hostname string) string {
+	return fmt.Sprintf("%s/%s", heartbeatPrefix, hostname)
+}
+
+// StartHeartbeat publishes this host's liveness key under a lease and keeps the
+// lease alive for the lifetime of ctx. When heartbeats are disabled
+// (heartbeatTTL <= 0) it is a no-op. The presence of this key is how other
+// hosts know this host is still alive and that its records must not be GC'd.
+func (er *EtcdRegistry) StartHeartbeat(ctx context.Context) error {
+	if er.heartbeatTTL <= 0 {
+		er.logger.Info().Msg("heartbeat disabled (heartbeat_ttl <= 0); cross-host GC will not run")
+		return nil
+	}
+
+	leaseResp, err := er.client.Grant(ctx, int64(er.heartbeatTTL))
+	if err != nil {
+		return fmt.Errorf("grant heartbeat lease: %w", err)
+	}
+
+	key := heartbeatKey(er.hostname)
+	if _, err := er.client.Put(ctx, key, er.hostname, clientv3.WithLease(leaseResp.ID)); err != nil {
+		_, _ = er.client.Revoke(ctx, leaseResp.ID)
+		return fmt.Errorf("put heartbeat key %q: %w", key, err)
+	}
+
+	kaCtx, cancel := context.WithCancel(ctx)
+	kaCh, err := er.client.KeepAlive(kaCtx, leaseResp.ID)
+	if err != nil {
+		cancel()
+		_, _ = er.client.Delete(ctx, key)
+		_, _ = er.client.Revoke(ctx, leaseResp.ID)
+		return fmt.Errorf("keepalive heartbeat lease: %w", err)
+	}
+
+	er.hbMu.Lock()
+	er.hbLease = leaseResp.ID
+	er.hbCancel = cancel
+	er.hbMu.Unlock()
+
+	// Drain keepalive responses until cancel; presence keeps the lease alive.
+	go func() {
+		for range kaCh {
+		}
+	}()
+
+	er.logger.Info().Str("key", key).Int("ttl", er.heartbeatTTL).Msg("heartbeat started")
+	return nil
+}
+
+// stopHeartbeat cancels the keepalive and best-effort removes the liveness key.
+func (er *EtcdRegistry) stopHeartbeat() {
+	er.hbMu.Lock()
+	cancel := er.hbCancel
+	lease := er.hbLease
+	er.hbCancel = nil
+	er.hbLease = 0
+	er.hbMu.Unlock()
+
+	if cancel == nil {
+		return
+	}
+	cancel()
+
+	ctx, cancelTimeout := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelTimeout()
+	if _, err := er.client.Delete(ctx, heartbeatKey(er.hostname)); err != nil {
+		er.logger.Warn().Err(err).Msg("delete heartbeat key on shutdown")
+	}
+	if _, err := er.client.Revoke(ctx, lease); err != nil {
+		er.logger.Warn().Err(err).Msg("revoke heartbeat lease on shutdown")
+	}
+}
+
+// GetLiveHostnames returns the set of hostnames with a live heartbeat key.
+// It returns (nil, nil) when heartbeats are disabled, which callers must treat
+// as "cross-host GC disabled" — never as "every host is dead".
+func (er *EtcdRegistry) GetLiveHostnames(ctx context.Context) (map[string]struct{}, error) {
+	if er.heartbeatTTL <= 0 {
+		return nil, nil
+	}
+
+	base := heartbeatPrefix
+	resp, err := er.client.Get(ctx, base+"/", clientv3.WithPrefix(), clientv3.WithKeysOnly(), clientv3.WithSerializable())
+	if err != nil {
+		return nil, fmt.Errorf("list heartbeat keys under %q: %w", base, err)
+	}
+
+	live := make(map[string]struct{}, len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		hostname := strings.TrimPrefix(string(kv.Key), base+"/")
+		if hostname == "" {
+			continue
+		}
+		live[hostname] = struct{}{}
+	}
+	// This host is always considered live while it is reconciling.
+	live[er.hostname] = struct{}{}
+	return live, nil
 }
 
 // getNextIndexedKey generates a new etcd key for a record based on its fully qualified domain name (fqdn).
@@ -266,5 +378,6 @@ func (er *EtcdRegistry) LockTransaction(ctx context.Context, keys []string, fn f
 }
 
 func (er *EtcdRegistry) Close() error {
+	er.stopHeartbeat()
 	return er.client.Close()
 }

--- a/internal/registry/etcd_registry_test.go
+++ b/internal/registry/etcd_registry_test.go
@@ -54,7 +54,7 @@ func TestNewEtcdRegistry(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
 
-	reg := NewEtcdRegistry(mock, cfg, "test-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "test-host", 0, testLogger())
 
 	if reg == nil {
 		t.Fatal("expected non-nil registry")
@@ -70,7 +70,7 @@ func TestNewEtcdRegistry(t *testing.T) {
 func TestEtcdRegistry_Register_CreatesKey(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
@@ -101,7 +101,7 @@ func TestEtcdRegistry_Register_CreatesKey(t *testing.T) {
 func TestEtcdRegistry_Register_ValueContainsRecordData(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
@@ -135,7 +135,7 @@ func TestEtcdRegistry_Register_ValueContainsRecordData(t *testing.T) {
 func TestEtcdRegistry_Register_IncrementsIndex(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Simulate existing keys x1 and x2
 	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -170,7 +170,7 @@ func TestEtcdRegistry_Register_GetError(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
@@ -192,7 +192,7 @@ func TestEtcdRegistry_Register_PutError(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
@@ -210,7 +210,7 @@ func TestEtcdRegistry_Register_PutError(t *testing.T) {
 func TestEtcdRegistry_Remove_DeletesMatchingKey(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Simulate existing key with matching record
 	existingValue, _ := json.Marshal(etcdRecord{
@@ -249,7 +249,7 @@ func TestEtcdRegistry_Remove_DeletesMatchingKey(t *testing.T) {
 func TestEtcdRegistry_Remove_NoMatchingKeys(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// No matching records
 	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -274,7 +274,7 @@ func TestEtcdRegistry_Remove_NoMatchingKeys(t *testing.T) {
 func TestEtcdRegistry_Remove_DoesNotDeleteNonMatching(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Existing key with different host
 	existingValue, _ := json.Marshal(etcdRecord{
@@ -314,7 +314,7 @@ func TestEtcdRegistry_Remove_DoesNotDeleteNonMatching(t *testing.T) {
 func TestEtcdRegistry_List_ReturnsAllRecords(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Create test records
 	record1, _ := json.Marshal(etcdRecord{
@@ -358,7 +358,7 @@ func TestEtcdRegistry_List_ReturnsAllRecords(t *testing.T) {
 func TestEtcdRegistry_List_HandlesInvalidJSON(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	validRecord, _ := json.Marshal(etcdRecord{
 		Host:               "192.168.1.1",
@@ -398,7 +398,7 @@ func TestEtcdRegistry_List_Error(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	_, err := reg.List(ctx)
@@ -411,7 +411,7 @@ func TestEtcdRegistry_List_Error(t *testing.T) {
 func TestEtcdRegistry_List_Empty(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	intents, err := reg.List(ctx)
@@ -428,7 +428,7 @@ func TestEtcdRegistry_List_Empty(t *testing.T) {
 func TestEtcdRegistry_Close(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	err := reg.Close()
 
@@ -448,7 +448,7 @@ func TestEtcdRegistry_Close_Error(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	err := reg.Close()
 
@@ -460,7 +460,7 @@ func TestEtcdRegistry_Close_Error(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_Success(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	executed := false
 	ctx := context.Background()
@@ -489,7 +489,7 @@ func TestEtcdRegistry_LockTransaction_Success(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_FunctionError(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 
@@ -516,7 +516,7 @@ func TestEtcdRegistry_LockTransaction_FunctionError(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_DeduplicatesKeys(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	grantCount := 0
 	mock.grantFunc = func(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error) {
@@ -543,7 +543,7 @@ func TestEtcdRegistry_LockTransaction_DeduplicatesKeys(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_ContextCancellation(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -577,7 +577,7 @@ func TestEtcdRegistry_Register_DifferentRecordTypes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := newMockEtcdClient()
 			cfg := testConfig()
-			reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+			reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 			ctx := context.Background()
 			intent := makeIntent("app.example.com", tt.value, tt.kind)
@@ -603,7 +603,7 @@ func TestEtcdRegistry_Register_DifferentRecordTypes(t *testing.T) {
 
 func TestEtcdRegistry_recordMatches(t *testing.T) {
 	cfg := testConfig()
-	reg := NewEtcdRegistry(nil, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(nil, cfg, "docker-host", 0, testLogger())
 
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
 
@@ -692,7 +692,7 @@ func TestEtcdRegistry_recordMatches(t *testing.T) {
 
 func TestEtcdRegistry_recordMatches_EmptyContainerId(t *testing.T) {
 	cfg := testConfig()
-	reg := NewEtcdRegistry(nil, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(nil, cfg, "docker-host", 0, testLogger())
 
 	rec, _ := domain.NewA("app.example.com", "192.168.1.1")
 	intent := &domain.RecordIntent{
@@ -730,7 +730,7 @@ func TestEtcdRegistry_Remove_GetError(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
@@ -745,7 +745,7 @@ func TestEtcdRegistry_Remove_GetError(t *testing.T) {
 func TestEtcdRegistry_Remove_MultipleMatches(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Multiple matching records
 	existingValue, _ := json.Marshal(etcdRecord{
@@ -783,7 +783,7 @@ func TestEtcdRegistry_Remove_MultipleMatches(t *testing.T) {
 func TestEtcdRegistry_Remove_SkipsInvalidJSON(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	validValue, _ := json.Marshal(etcdRecord{
 		Host:               "192.168.1.1",
@@ -820,7 +820,7 @@ func TestEtcdRegistry_Remove_SkipsInvalidJSON(t *testing.T) {
 func TestEtcdRegistry_Remove_SkipsNonChildKeys(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	existingValue, _ := json.Marshal(etcdRecord{
 		Host:               "192.168.1.1",
@@ -866,7 +866,7 @@ func TestEtcdRegistry_LockTransaction_GrantError(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 
@@ -894,7 +894,7 @@ func TestEtcdRegistry_LockTransaction_TxnError(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 
@@ -914,7 +914,7 @@ func TestEtcdRegistry_LockTransaction_KeepAliveError(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	ctx := context.Background()
 
@@ -933,7 +933,7 @@ func TestEtcdRegistry_LockTransaction_KeepAliveError(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_EmptyKeys(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	executed := false
 	ctx := context.Background()
@@ -960,7 +960,7 @@ func TestEtcdRegistry_LockTransaction_EmptyKeys(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_MultipleKeys(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	grantCount := 0
 	mock.grantFunc = func(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error) {
@@ -991,7 +991,7 @@ func TestEtcdRegistry_LockTransaction_MultipleKeys(t *testing.T) {
 func TestEtcdRegistry_getNextIndexedKey_GapFilling(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Simulate existing keys with gaps: x1, x3, x5
 	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -1021,7 +1021,7 @@ func TestEtcdRegistry_getNextIndexedKey_GapFilling(t *testing.T) {
 func TestEtcdRegistry_getNextIndexedKey_NonNumericSuffix(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Keys with non-numeric suffixes should be ignored
 	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -1054,7 +1054,7 @@ func TestEtcdRegistry_getNextIndexedKey_NonNumericSuffix(t *testing.T) {
 func TestEtcdRegistry_Remove_BatchDeleteError(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	intent := makeIntent("app.example.com", "192.168.1.1", domain.RecordA)
 	value, _ := json.Marshal(etcdRecord{
@@ -1102,7 +1102,7 @@ func TestEtcdRegistry_LockTransaction_ContextCancelDuringRetry(t *testing.T) {
 		LockTimeout:       5.0, // Long timeout
 		LockRetryInterval: 0.01,
 	}
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Make Txn always fail to acquire (Succeeded = false)
 	mock.txnFunc = func(ctx context.Context) clientv3.Txn {
@@ -1142,7 +1142,7 @@ func TestEtcdRegistry_LockTransaction_AcquireTimeout(t *testing.T) {
 		LockTimeout:       0.05, // Very short timeout
 		LockRetryInterval: 0.01,
 	}
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Make Txn always fail to acquire (Succeeded = false)
 	mock.txnFunc = func(ctx context.Context) clientv3.Txn {
@@ -1176,7 +1176,7 @@ func TestEtcdRegistry_LockTransaction_RevokeTimeoutError(t *testing.T) {
 		LockTimeout:       0.05,
 		LockRetryInterval: 0.01,
 	}
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Make Txn fail to acquire but revoke also fails
 	mock.txnFunc = func(ctx context.Context) clientv3.Txn {
@@ -1208,7 +1208,7 @@ func TestEtcdRegistry_LockTransaction_RevokeTimeoutError(t *testing.T) {
 func TestEtcdRegistry_LockTransaction_DeleteAndRevokeErrorsDuringRelease(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	executed := false
 
@@ -1252,7 +1252,7 @@ func TestEtcdRegistry_LockTransaction_DeleteAndRevokeErrorsDuringRelease(t *test
 func TestEtcdRegistry_getNextIndexedKey_ConsecutiveIndices(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Simulate existing keys: x1, x2, x3 (consecutive)
 	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -1282,7 +1282,7 @@ func TestEtcdRegistry_getNextIndexedKey_ConsecutiveIndices(t *testing.T) {
 func TestEtcdRegistry_getNextIndexedKey_KeyWithoutSlash(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Keys that don't have the base+/ prefix should be skipped
 	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -1313,7 +1313,7 @@ func TestEtcdRegistry_getNextIndexedKey_KeyWithoutSlash(t *testing.T) {
 func TestEtcdRegistry_Remove_ContainerIdEmpty(t *testing.T) {
 	mock := newMockEtcdClient()
 	cfg := testConfig()
-	reg := NewEtcdRegistry(mock, cfg, "docker-host", testLogger())
+	reg := NewEtcdRegistry(mock, cfg, "docker-host", 0, testLogger())
 
 	// Create intent with empty container ID (wildcard match)
 	intent := &domain.RecordIntent{

--- a/internal/registry/etcd_wire.go
+++ b/internal/registry/etcd_wire.go
@@ -10,6 +10,7 @@ import (
 
 type etcdRecord struct {
 	Host               string            `json:"host"`
+	TTL                uint32            `json:"ttl,omitempty"`
 	Kind               domain.RecordKind `json:"record_type"`
 	OwnerHostname      string            `json:"owner_hostname"`
 	OwnerContainerId   string            `json:"owner_container_id"`
@@ -21,6 +22,7 @@ type etcdRecord struct {
 func marshalEtcdValue(ri *domain.RecordIntent) (string, error) {
 	wire := etcdRecord{
 		Host:               ri.Record.Value,
+		TTL:                ri.TTL,
 		Kind:               ri.Record.Kind,
 		OwnerHostname:      ri.Hostname,
 		OwnerContainerId:   ri.ContainerId,
@@ -54,6 +56,7 @@ func unmarshalEtcdValue(key string, raw string, prefix string) (*domain.RecordIn
 		Created:       wire.Created,
 		Hostname:      wire.OwnerHostname,
 		Force:         wire.Force,
+		TTL:           wire.TTL,
 		Record:        rec,
 	}, nil
 }

--- a/internal/registry/etcd_wire_test.go
+++ b/internal/registry/etcd_wire_test.go
@@ -362,6 +362,123 @@ func TestEtcdRecord_JSONFieldNames(t *testing.T) {
 	}
 }
 
+func TestMarshalEtcdValue_TTLOmittedWhenZero(t *testing.T) {
+	rec, _ := domain.NewA("app.example.com", "192.168.1.1")
+	ri := &domain.RecordIntent{
+		ContainerId:   "abc123",
+		ContainerName: "my-app",
+		Created:       time.Now(),
+		Hostname:      "docker-host",
+		Record:        rec,
+		TTL:           0,
+	}
+
+	result, err := marshalEtcdValue(ri)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if contains(result, `"ttl"`) {
+		t.Errorf("expected ttl to be omitted when zero, got: %s", result)
+	}
+}
+
+func TestMarshalEtcdValue_TTLPresentWhenSet(t *testing.T) {
+	rec, _ := domain.NewA("app.example.com", "192.168.1.1")
+	ri := &domain.RecordIntent{
+		ContainerId:   "abc123",
+		ContainerName: "my-app",
+		Created:       time.Now(),
+		Hostname:      "docker-host",
+		Record:        rec,
+		TTL:           300,
+	}
+
+	result, err := marshalEtcdValue(ri)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var wire etcdRecord
+	if err := json.Unmarshal([]byte(result), &wire); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if wire.TTL != 300 {
+		t.Errorf("expected TTL 300, got %d", wire.TTL)
+	}
+	if !contains(result, `"ttl":300`) {
+		t.Errorf("expected ttl field in JSON, got: %s", result)
+	}
+}
+
+func TestUnmarshalEtcdValue_TTL(t *testing.T) {
+	key := "/skydns/com/example/app/x1"
+	value := `{
+		"host": "192.168.1.1",
+		"ttl": 120,
+		"record_type": "A",
+		"owner_hostname": "docker-host",
+		"owner_container_id": "abc123",
+		"owner_container_name": "my-app",
+		"created": "2024-01-15T10:30:00Z",
+		"force": false
+	}`
+
+	result, err := unmarshalEtcdValue(key, value, "/skydns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.TTL != 120 {
+		t.Errorf("expected TTL 120, got %d", result.TTL)
+	}
+}
+
+func TestUnmarshalEtcdValue_TTLDefaultsToZeroWhenAbsent(t *testing.T) {
+	// Records written before TTL support omit the field; they must still parse.
+	key := "/skydns/com/example/app/x1"
+	value := `{
+		"host": "192.168.1.1",
+		"record_type": "A",
+		"owner_hostname": "docker-host",
+		"owner_container_id": "abc123",
+		"owner_container_name": "my-app",
+		"created": "2024-01-15T10:30:00Z",
+		"force": false
+	}`
+
+	result, err := unmarshalEtcdValue(key, value, "/skydns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.TTL != 0 {
+		t.Errorf("expected TTL 0 for legacy record, got %d", result.TTL)
+	}
+}
+
+func TestMarshalUnmarshal_TTLRoundtrip(t *testing.T) {
+	rec, _ := domain.NewA("app.example.com", "192.168.1.1")
+	original := &domain.RecordIntent{
+		ContainerId:   "abc123",
+		ContainerName: "my-app",
+		Created:       time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Hostname:      "docker-host",
+		Record:        rec,
+		TTL:           600,
+	}
+
+	marshaled, err := marshalEtcdValue(original)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	key := keyBaseForFQDN("/skydns", "app.example.com") + "/x1"
+	result, err := unmarshalEtcdValue(key, marshaled, "/skydns")
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if result.TTL != original.TTL {
+		t.Errorf("TTL mismatch: %d vs %d", result.TTL, original.TTL)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }

--- a/internal/registry/heartbeat_test.go
+++ b/internal/registry/heartbeat_test.go
@@ -1,0 +1,206 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func TestEtcdRegistry_StartHeartbeat_Disabled(t *testing.T) {
+	mock := newMockEtcdClient()
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 0, testLogger())
+
+	if err := reg.StartHeartbeat(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.grantCalled || mock.putCalled {
+		t.Error("expected no etcd writes when heartbeat is disabled")
+	}
+}
+
+func TestEtcdRegistry_StartHeartbeat_WritesLeasedKey(t *testing.T) {
+	mock := newMockEtcdClient()
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := reg.StartHeartbeat(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mock.grantCalled {
+		t.Error("expected Grant to be called")
+	}
+	if !mock.keepAliveCalled {
+		t.Error("expected KeepAlive to be called")
+	}
+	if len(mock.putKeys) != 1 {
+		t.Fatalf("expected 1 put, got %d", len(mock.putKeys))
+	}
+	wantKey := "/docker-coredns-sync/heartbeat/docker-host"
+	if mock.putKeys[0] != wantKey {
+		t.Errorf("expected heartbeat key %q, got %q", wantKey, mock.putKeys[0])
+	}
+	if mock.putValues[0] != "docker-host" {
+		t.Errorf("expected heartbeat value 'docker-host', got %q", mock.putValues[0])
+	}
+	if reg.hbLease == 0 {
+		t.Error("expected heartbeat lease to be recorded")
+	}
+}
+
+func TestEtcdRegistry_StartHeartbeat_GrantError(t *testing.T) {
+	mock := newMockEtcdClient()
+	mock.grantFunc = func(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error) {
+		return nil, errors.New("boom")
+	}
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	if err := reg.StartHeartbeat(context.Background()); err == nil {
+		t.Fatal("expected error when grant fails")
+	}
+}
+
+func TestEtcdRegistry_StartHeartbeat_PutErrorRevokes(t *testing.T) {
+	mock := newMockEtcdClient()
+	mock.putFunc = func(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+		return nil, errors.New("boom")
+	}
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	if err := reg.StartHeartbeat(context.Background()); err == nil {
+		t.Fatal("expected error when put fails")
+	}
+	if !mock.revokeCalled {
+		t.Error("expected lease to be revoked after put failure")
+	}
+}
+
+func TestEtcdRegistry_StartHeartbeat_KeepAliveErrorCleansUp(t *testing.T) {
+	mock := newMockEtcdClient()
+	mock.keepAliveFunc = func(ctx context.Context, id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error) {
+		return nil, errors.New("boom")
+	}
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	if err := reg.StartHeartbeat(context.Background()); err == nil {
+		t.Fatal("expected error when keepalive fails")
+	}
+	if !mock.deleteCalled {
+		t.Error("expected heartbeat key to be deleted after keepalive failure")
+	}
+	if !mock.revokeCalled {
+		t.Error("expected lease to be revoked after keepalive failure")
+	}
+}
+
+func TestEtcdRegistry_Close_NoHeartbeatStarted(t *testing.T) {
+	mock := newMockEtcdClient()
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 0, testLogger())
+
+	// stopHeartbeat must be a no-op (no delete/revoke) when never started.
+	if err := reg.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.deleteCalled || mock.revokeCalled {
+		t.Error("expected no heartbeat cleanup when heartbeat was never started")
+	}
+}
+
+func TestEtcdRegistry_GetLiveHostnames_SkipsEmptySuffix(t *testing.T) {
+	mock := newMockEtcdClient()
+	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+		return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
+			{Key: []byte("/docker-coredns-sync/heartbeat/")}, // malformed: empty hostname
+			{Key: []byte("/docker-coredns-sync/heartbeat/host-a")},
+		}}, nil
+	}
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	live, err := reg.GetLiveHostnames(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := live[""]; ok {
+		t.Error("expected empty hostname to be skipped")
+	}
+	if _, ok := live["host-a"]; !ok {
+		t.Error("expected host-a to be present")
+	}
+}
+
+func TestEtcdRegistry_GetLiveHostnames_Disabled(t *testing.T) {
+	mock := newMockEtcdClient()
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 0, testLogger())
+
+	live, err := reg.GetLiveHostnames(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if live != nil {
+		t.Errorf("expected nil set when heartbeat disabled, got %v", live)
+	}
+}
+
+func TestEtcdRegistry_GetLiveHostnames_ParsesKeysAndIncludesSelf(t *testing.T) {
+	mock := newMockEtcdClient()
+	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+		return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
+			{Key: []byte("/docker-coredns-sync/heartbeat/host-a")},
+			{Key: []byte("/docker-coredns-sync/heartbeat/host-b")},
+		}}, nil
+	}
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	live, err := reg.GetLiveHostnames(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"host-a", "host-b", "docker-host"} {
+		if _, ok := live[want]; !ok {
+			t.Errorf("expected %q in live set, got %v", want, live)
+		}
+	}
+	if len(live) != 3 {
+		t.Errorf("expected 3 live hosts, got %d (%v)", len(live), live)
+	}
+}
+
+func TestEtcdRegistry_GetLiveHostnames_GetError(t *testing.T) {
+	mock := newMockEtcdClient()
+	mock.getFunc = func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+		return nil, errors.New("boom")
+	}
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	if _, err := reg.GetLiveHostnames(context.Background()); err == nil {
+		t.Fatal("expected error when get fails")
+	}
+}
+
+func TestEtcdRegistry_Close_StopsHeartbeat(t *testing.T) {
+	mock := newMockEtcdClient()
+	reg := NewEtcdRegistry(mock, testConfig(), "docker-host", 30, testLogger())
+
+	if err := reg.StartHeartbeat(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mock.reset()
+
+	if err := reg.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mock.deleteCalled {
+		t.Error("expected heartbeat key to be deleted on close")
+	}
+	if !mock.revokeCalled {
+		t.Error("expected heartbeat lease to be revoked on close")
+	}
+	if !mock.closeCalled {
+		t.Error("expected underlying client to be closed")
+	}
+}


### PR DESCRIPTION
Implements the v0.7.0 **P3** issues. Closes #14, #13, #16. Also closes #15 as won't-do (done separately on the issue tracker).

## Design decisions resolved before implementing
- **#13 GC model** → heartbeat + grace-TTL (decentralized; survives any single node dying).
- **#15 live reload** → won't-do (restart is cheap in the target deployment; the safe/unsafe key split + config-holder refactor isn't worth the footgun surface).
- **#14 / #16** → sensible defaults, no user decision required.

## Changes

### Per-record TTL (#14)
- `app.record_ttl` global default + `coredns.<kind>[.<alias>].ttl` per-record label override.
- Serialized as `ttl,omitempty` in the etcd value — `0` omits the field so CoreDNS applies its own default. Records written before this change (no `ttl`) still parse.
- TTL is part of `RecordIntent.Key()`/`Equal()`, so a TTL-only change is treated as drift and self-heals on the next reconcile.

### Cross-host orphan GC via heartbeat (#13)
- Each host publishes a lease-backed liveness key under `/docker-coredns-sync/heartbeat/<hostname>` (outside `etcd.path_prefix`, so CoreDNS and `List()` never see it) and keeps it alive for the process lifetime.
- Reconciliation removes records whose owner has **no live heartbeat**, cleaning up after permanently-decommissioned hosts.
- `app.heartbeat_ttl` (default `30s`) is the lease TTL **and** the grace period — a host must be silent longer than this before its records are GC-eligible, so transient outages/restarts don't trigger premature deletion.
- `heartbeat_ttl <= 0` disables heartbeats and cross-host GC, restoring the original owner-only removal behavior (`liveHostnames` is `nil` ⇒ exact prior code path). Safe by default.

### Startup warning (#16)
- Prominent startup warning when `app.host_ipv4`/`app.host_ipv6` is unset, making it obvious that value-less A/AAAA records will be skipped.

## Upgrade note (multi-host)
Roll this out to all hosts together: a host on an older version won't publish a heartbeat and would look "dead" to upgraded hosts, which would then GC its records. Documented in README + CHANGELOG.

## Testing
- `go build`, `go vet`, `go test ./...`, and `go test -race` (core + registry) all pass.
- Coverage held: core 98.4%, registry 98.1%, config/domain/app 100%.
- New tests: label TTL parsing (incl. invalid-ignored, alias), builder TTL resolution/precedence, wire round-trip (legacy + omitempty), `Key`/`Equal` TTL drift, heartbeat lifecycle + `GetLiveHostnames`, and all reconciliation GC paths (dead host removed, live host kept, GC-disabled, own-stale still removed, live-fetch error skips GC).

> Note: `golangci-lint` could not run in CI's sandbox here due to a toolchain version mismatch (its Go 1.25 vs. the repo's 1.26.3); `go vet` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTuzezx61feBSLbuqAf7Te

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTuzezx61feBSLbuqAf7Te)_