### PR TITLE
docs: document label case-sensitivity and fix stale README defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   container must be absent for two consecutive resyncs) so a container that is
   only transiently missing from a single snapshot is not removed. (#8)
 
+### Documentation
+- Documented Docker label case-sensitivity rules in the README: the prefix,
+  field names (`name`/`value`/`force`/`ttl`), and aliases are case-sensitive
+  (a wrong-case segment is silently ignored), while record kinds and boolean
+  values are case-insensitive. Fixed stale config-reference defaults: `app.hostname`
+  is `""` and required (not `"your-hostname"`), and the non-existent `app.host_ip`
+  / `127.0.0.1` entry is replaced with the real `app.host_ipv4` / `app.host_ipv6`
+  keys (both default `""`). Also corrected the AAAA label example, which had been
+  copy-pasted from the A record. (#17)
+
 ### Notes
 - When upgrading a multi-host fleet, roll out to all hosts together: a host
   running an older version doesn't publish a heartbeat, so it could be treated as

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 - `coredns.a.value=192.168.1.123` *(optional, defaults to `host_ipv4`)*
 
 ### AAAA Record
-- `coredns.a.name=foo.example.com`
-- `coredns.a.value=fd20:0:1::123` *(optional, defaults to `host_ipv6`)*
+- `coredns.aaaa.name=foo.example.com`
+- `coredns.aaaa.value=fd20:0:1::123` *(optional, defaults to `host_ipv6`)*
 
 ### CNAME Record
 
@@ -64,6 +64,20 @@ coredns.cname.app.value=target.example.com
   `coredns.a.proxy.ttl=60`). A non-numeric value is ignored. When neither a
   label nor `app.record_ttl` sets a TTL, the field is omitted and CoreDNS
   applies its own default.
+
+### Case sensitivity
+
+Label parsing treats each segment of a label key differently, and getting the
+case wrong on a case-sensitive segment causes the label to be **silently
+ignored** rather than reported as an error:
+
+| Segment | Example | Case-sensitive? | Notes |
+|---------|---------|-----------------|-------|
+| Prefix | `coredns` in `coredns.a.name` | **Yes** | Must match `app.docker_label_prefix` exactly. `Coredns.a.name` is not recognized. |
+| Record kind | `a` / `aaaa` / `cname` | No | Normalized case-insensitively, so `coredns.A.name` and `coredns.a.name` are equivalent. |
+| Field | `name` / `value` / `force` / `ttl` | **Yes** | Must be lowercase. `coredns.a.Name` is silently ignored. |
+| Alias | `proxy` in `coredns.a.proxy.name` | **Yes** | Used verbatim; the alias only groups a record's fields together and is not otherwise interpreted. |
+| Boolean values | `true` for `coredns.enabled` / `coredns.force` | No | `true`, `True`, and `TRUE` are all accepted. |
 
 ---
 
@@ -106,8 +120,9 @@ Configuration values can be provided via:
 |------|------------|---------|------|---------|-------------|
 | `--app.allowed-record-types` | `app.allowed_record_types` | `DOCKER_COREDNS_SYNC_APP_ALLOWED_RECORD_TYPES` | `[]string` | `["A", "CNAME"]` | DNS record types to allow |
 | `--app.docker-label-prefix` | `app.docker_label_prefix` | `DOCKER_COREDNS_SYNC_APP_DOCKER_LABEL_PREFIX` | `string` | `"coredns"` | Docker label namespace |
-| `--app.host-ip` | `app.host_ip` | `DOCKER_COREDNS_SYNC_APP_HOST_IP` | `string` | `"127.0.0.1"` | IP to use for A records |
-| `--app.hostname` | `app.hostname` | `DOCKER_COREDNS_SYNC_APP_HOSTNAME` | `string` | `"your-hostname"` | Unique logical hostname for this node |
+| `--app.host-ipv4` | `app.host_ipv4` | `DOCKER_COREDNS_SYNC_APP_HOST_IPV4` | `string` | `""` | Default IPv4 address for value-less A records. When empty, A records without an explicit value are skipped |
+| `--app.host-ipv6` | `app.host_ipv6` | `DOCKER_COREDNS_SYNC_APP_HOST_IPV6` | `string` | `""` | Default IPv6 address for value-less AAAA records. When empty, AAAA records without an explicit value are skipped |
+| `--app.hostname` | `app.hostname` | `DOCKER_COREDNS_SYNC_APP_HOSTNAME` | `string` | `""` | Unique logical hostname for this node. **Required** — startup fails if empty |
 | `--app.poll-interval` | `app.poll_interval` | `DOCKER_COREDNS_SYNC_APP_POLL_INTERVAL` | `int` | `5` | How often to reconcile the registry (in seconds) |
 | `--app.dry-run` | `app.dry_run` | `DOCKER_COREDNS_SYNC_APP_DRY_RUN` | `bool` | `false` | Log planned etcd changes without applying them |
 | `--app.record-ttl` | `app.record_ttl` | `DOCKER_COREDNS_SYNC_APP_RECORD_TTL` | `uint` | `0` | Default DNS record TTL in seconds (`0` = unset; CoreDNS uses its own default). Overridable per record via a `coredns.<kind>[.<alias>].ttl` label |


### PR DESCRIPTION
## Summary

Documentation fixes for the Docker label parsing rules and stale entries in the README config reference.

- **Case-sensitivity rules** — adds a "Case sensitivity" table to the Docker Label Configuration section, documenting that the prefix, field names (`name`/`value`/`force`/`ttl`), and aliases are **case-sensitive** (a wrong-case segment is silently ignored), while record kinds and boolean values are case-insensitive. Behavior verified against `internal/core/labels.go` and `internal/domain/record_factory.go`.
- **Stale `app.hostname` default** — corrected from `"your-hostname"` to `""`, noting it is required and that startup fails when empty (`internal/config/config.go`).
- **Stale `app.host_ip` row** — the config table referenced a `--app.host-ip` / `app.host_ip` / `127.0.0.1` key that does not exist. Replaced it with the real `app.host_ipv4` and `app.host_ipv6` keys (both default `""`).
- **AAAA label example** — corrected `coredns.a.*` → `coredns.aaaa.*`; it had been copy-pasted from the A record.
- **CHANGELOG** — added a `### Documentation` entry under `## [Unreleased]`.

## Testing

Docs-only change; no Go source touched. `go build ./...` passes. Confirmed no remaining references to the removed `host_ip` config key.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wFmavFQqpdDT4mC69Uiau)_